### PR TITLE
Make sure the image is no larger than the screen

### DIFF
--- a/static/image.css
+++ b/static/image.css
@@ -37,7 +37,7 @@
      * ensure the image is not larger than its container (e. g. the surrounding Bootstrap container)
      */
     max-width: 100%;
-    max-height: 100%;
+    max-height: 100vh;
 }
 
 .wd-image-positions--image.wd-image-positions--active ~ * button:not(.wd-image-positions--active) {


### PR DESCRIPTION
The parent would expand it height indefinitely or until the width reached 100% of the parent. This caused portrait images on wide screens always cause a lot of scrolling and often only a part of the image would be visible at the same time making it tricky to annotate it.